### PR TITLE
Make `OntologyConverter` use the manager of the ontology provided instead of a new one

### DIFF
--- a/src/main/java/de/uni_stuttgart/vis/vowl/owl2vowl/converter/AbstractConverter.java
+++ b/src/main/java/de/uni_stuttgart/vis/vowl/owl2vowl/converter/AbstractConverter.java
@@ -17,7 +17,6 @@ import de.uni_stuttgart.vis.vowl.owl2vowl.parser.vowl.property.ObjectPropertyVis
 import de.uni_stuttgart.vis.vowl.owl2vowl.parser.vowl.property.VowlSubclassPropertyGenerator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.*;
 import org.semanticweb.owlapi.model.parameters.Imports;
 import org.semanticweb.owlapi.search.EntitySearcher;
@@ -39,8 +38,6 @@ public abstract class AbstractConverter implements Converter {
 	protected boolean initialized = false;
 
 	private void preLoadOntology() {
-		initApi();
-
 		try {
 			loadOntology();
 		} catch (OWLOntologyCreationException e) {
@@ -134,10 +131,6 @@ public abstract class AbstractConverter implements Converter {
 		vowlData.getEntityMap().values().forEach(entity -> entity.accept(new EquivalentSorter(ontology.getOntologyID().getOntologyIRI().orElse(IRI
 				.create(loadedOntologyPath)), vowlData)));
 		new BaseIriCollector(vowlData).execute();
-	}
-
-	private void initApi() {
-		manager = OWLManager.createOWLOntologyManager();
 	}
 
 	/**

--- a/src/main/java/de/uni_stuttgart/vis/vowl/owl2vowl/converter/IRIConverter.java
+++ b/src/main/java/de/uni_stuttgart/vis/vowl/owl2vowl/converter/IRIConverter.java
@@ -7,6 +7,7 @@ import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 
 import java.util.Collection;
 import java.util.Collections;
+import org.semanticweb.owlapi.apibinding.OWLManager;
 
 public class IRIConverter extends AbstractConverter {
 	protected IRI mainOntology;
@@ -26,6 +27,8 @@ public class IRIConverter extends AbstractConverter {
 	protected void loadOntology() throws OWLOntologyCreationException {
 		logger.info("Converting IRIs...");
 		logger.info("Loading ontologies ... [" + mainOntology + ",  " + depdencyOntologies + "]");
+		
+		manager = OWLManager.createOWLOntologyManager();
 
 		if (!depdencyOntologies.isEmpty()) {
 			for (IRI externalIRI : depdencyOntologies) {
@@ -35,15 +38,15 @@ public class IRIConverter extends AbstractConverter {
 		}
 
 		ontology = manager.loadOntology(mainOntology);
-		String logOntoName = mainOntology.toString();
 		loadedOntologyPath = mainOntology.toString();
 
+		String logOntoName;
 		if (!ontology.isAnonymous()) {
 			logOntoName = ontology.getOntologyID().getOntologyIRI().get().toString();
 		} else {
+			logOntoName = mainOntology.toString();
 			logger.info("Ontology IRI is anonymous. Use loaded URI/IRI instead.");
 		}
-
 		logger.info("Ontologies loaded! Main Ontology: " + logOntoName);
 	}
 }

--- a/src/main/java/de/uni_stuttgart/vis/vowl/owl2vowl/converter/InputStreamConverter.java
+++ b/src/main/java/de/uni_stuttgart/vis/vowl/owl2vowl/converter/InputStreamConverter.java
@@ -7,6 +7,7 @@ import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.Collections;
+import org.semanticweb.owlapi.apibinding.OWLManager;
 
 /**
  *
@@ -28,21 +29,23 @@ public class InputStreamConverter extends AbstractConverter {
 	@Override
 	protected void loadOntology() throws OWLOntologyCreationException {
 		logger.info("Converting input streams...");
+		
+		manager = OWLManager.createOWLOntologyManager();
 
 		for (InputStream depdencyOntology : depdencyOntologies) {
 			manager.loadOntologyFromOntologyDocument(depdencyOntology);
 		}
 
 		ontology = manager.loadOntologyFromOntologyDocument(mainOntology);
-		String logOntoName = "Anonymous";
 		loadedOntologyPath = "file upload";
 
+		String logOntoName;
 		if (!ontology.isAnonymous()) {
 			logOntoName = ontology.getOntologyID().getOntologyIRI().get().toString();
 		} else {
+			logOntoName = "Anonymous";
 			logger.info("Ontology IRI is anonymous. Use loaded URI/IRI instead.");
 		}
-
 		logger.info("Ontologies loaded! Main Ontology: " + logOntoName);
 	}
 }

--- a/src/main/java/de/uni_stuttgart/vis/vowl/owl2vowl/converter/OntologyConverter.java
+++ b/src/main/java/de/uni_stuttgart/vis/vowl/owl2vowl/converter/OntologyConverter.java
@@ -22,20 +22,19 @@ public class OntologyConverter extends AbstractConverter {
 
 	@Override
 	protected void loadOntology() throws OWLOntologyCreationException {
-
 		logger.info("Converting Ontolgy...");
 		logger.info("Loading ontology ... [" + ontology + "]");
 
-
-		String logOntoName = "Anonymous";
+		manager = ontology.getOWLOntologyManager();
 		loadedOntologyPath = "Direct ontology";
 
+		String logOntoName;
 		if (!ontology.isAnonymous()) {
 			logOntoName = ontology.getOntologyID().getOntologyIRI().get().toString();
 		} else {
+			logOntoName = "Anonymous";
 			logger.info("Ontology IRI is anonymous.");
 		}
-
 		logger.info("Ontologies loaded! Main Ontology: " + logOntoName);
 	}
 }


### PR DESCRIPTION
This pull request fixes the following issue.

#### Steps to reproduce
(Need to define `getMyOntology()` somehow.)

```java
@Test
public void testOntologyConverter() throws Exception
{
	OWLOntology ontology = getMyOntology();
	Converter converter = new OntologyConverter(ontology);
	converter.convert();
	converter.export(new Exporter() {
		@Override
		public void write(String text) throws Exception {
		}
	});
}

```

#### Actual result
```
org.semanticweb.owlapi.model.UnknownOWLOntologyException: Unknown ontology: OntologyID(OntologyIRI(<http://example.com/my-ontology>) VersionIRI(<null>))
	at uk.ac.manchester.cs.owl.owlapi.OWLOntologyManagerImpl.getImports(OWLOntologyManagerImpl.java:439)
	at de.uni_stuttgart.vis.vowl.owl2vowl.parser.vowl.ImportedChecker.execute(ImportedChecker.java:33)
	at de.uni_stuttgart.vis.vowl.owl2vowl.converter.AbstractConverter.postParsing(AbstractConverter.java:133)
	at de.uni_stuttgart.vis.vowl.owl2vowl.converter.AbstractConverter.convert(AbstractConverter.java:164)
...
```

#### Expected result
The ontology is converted successfully.

#### Root cause
The `manager` is defined in `AbstractConverter.java:140`:

```
manager = OWLManager.createOWLOntologyManager();
```

`ImportedChecker.java:33` contains the following line of code:

```java
Set<OWLOntology> imports = manager.getImports(loadedOntology);
```

This throws `UnknownOWLOntologyException` because the `loadedOntology` was loaded in *other* ontology manager.
