### PR TITLE
Remove default file logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,14 @@ This war can be execute like a jar file to start a local server.
 It would be a pain always building the jar only to test some new implemented stuff. We included a possiblity to run the conversion directly with the IDE. For this you need to change the `ConverterImpl.java` class.
 
 To run a Spring Server directly from the IDE you have to start the `ServerMain.java` class.
+
+FAQ
+==================
+
+## I want to log information, errors, etc to files. Is there a default configuration?
+If you want to use logging to files there is log4j2 configuration provided under ```src/main/resources/log4j2-spring-file.xml```.
+
+- JAR/IDE: To load it you have to provide a JVM argument. For example if you have the JAR you have to exeecute:
+       ```java -Dlog4j.configurationFile=path/to/log4j2-spring-file.xml -jar ...```
+- WAR: Uncomment the line in ```src/main/resources/application.properties```        
+  

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,4 @@
 spring.http.multipart.max-file-size=10MB
 spring.http.multipart.max-request-size=10MB
+!remove comment if you want to use extra file logger in the war
+!logging.config=log4j2-spring-file.xml

--- a/src/main/resources/log4j2-spring-file.xml
+++ b/src/main/resources/log4j2-spring-file.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN">
 	<Properties>
+		<Property name="log-dir">logs</Property>
 		<Property name="PID">????</Property>
 		<Property name="LOG_EXCEPTION_CONVERSION_WORD">%xwEx</Property>
 		<Property name="LOG_LEVEL_PATTERN">%5p</Property>
@@ -11,6 +12,32 @@
 		<Console name="Console" target="SYSTEM_OUT" follow="true">
 			<PatternLayout pattern="${sys:CONSOLE_LOG_PATTERN}" />
 		</Console>
+		<RollingFile name="File" fileName="${log-dir}/log.log" filePattern="logs/$${date:yyyy-MM}/app-%d{yyyy-MM-dd-HH}-%i.log.gz">
+			<PatternLayout>
+				<Pattern>${sys:FILE_LOG_PATTERN}</Pattern>
+			</PatternLayout>
+			<Policies>
+				<SizeBasedTriggeringPolicy size="10 MB" />
+			</Policies>
+		</RollingFile>
+
+		<RollingFile name="Conversion_File" fileName="${log-dir}/conversions.log" filePattern="logs/$${date:yyyy-MM}/conversion-%d{yyyy-MM-dd-HH}-%i.log.gz">
+			<PatternLayout>
+				<Pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} - %msg%n</Pattern>
+			</PatternLayout>
+			<Policies>
+				<TimeBasedTriggeringPolicy>1</TimeBasedTriggeringPolicy>
+			</Policies>
+		</RollingFile>
+
+		<RollingFile name="Ontology_Structure" fileName="${log-dir}/structure.log" filePattern="logs/$${date:yyyy-MM}/structure-%d{yyyy-MM-dd-HH}-%i.log.gz">
+			<PatternLayout>
+				<Pattern>${sys:FILE_LOG_PATTERN}</Pattern>
+			</PatternLayout>
+			<Policies>
+				<TimeBasedTriggeringPolicy>1</TimeBasedTriggeringPolicy>
+			</Policies>
+		</RollingFile>
 	</Appenders>
 	<Loggers>
 		<Logger name="org.apache.catalina.startup.DigesterFactory" level="error" />
@@ -25,8 +52,15 @@
 		<logger name="org.springframework.boot.actuate.autoconfigure.CrshAutoConfiguration" level="warn"/>
 		<logger name="org.springframework.boot.actuate.endpoint.jmx" level="warn"/>
 		<logger name="org.thymeleaf" level="warn"/>
+		<logger name="de.uni_stuttgart.vis.vowl.owl2vowl">
+			<AppenderRef ref="Ontology_Structure" level="info"/>
+		</logger>
+		<logger name="conversion-logger">
+			<AppenderRef ref="Conversion_File" level="info"/>
+		</logger>
 		<Root level="info">
 			<AppenderRef ref="Console" />
+			<AppenderRef ref="File" />
 		</Root>
 	</Loggers>
 </Configuration>


### PR DESCRIPTION
Now in the default configuration logging is only to console.
If required file log configuration can be loaded described in FAQ.

Closes #35 