### PR TITLE
Logging improvements & dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,7 @@
 							<dependency>
 								<groupId>org.springframework.boot</groupId>
 								<artifactId>spring-boot-maven-plugin</artifactId>
-								<version>1.5.3.RELEASE</version>
+								<version>1.5.6.RELEASE</version>
 							</dependency>
 						</dependencies>
 						<configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -181,20 +181,20 @@
 							</execution>
 						</executions>
 					</plugin>
-					<!--<plugin>-->
-						<!--<groupId>org.apache.maven.plugins</groupId>-->
-						<!--<artifactId>maven-gpg-plugin</artifactId>-->
-						<!--<version>1.6</version>-->
-						<!--<executions>-->
-							<!--<execution>-->
-								<!--<id>sign-artifacts</id>-->
-								<!--<phase>verify</phase>-->
-								<!--<goals>-->
-									<!--<goal>sign</goal>-->
-								<!--</goals>-->
-							<!--</execution>-->
-						<!--</executions>-->
-					<!--</plugin>-->
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>1.6</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
 				</plugins>
 			</build>
 		</profile>

--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,45 @@
 				</property>
 			</activation>
 
+			<dependencies>
+
+				<dependency>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-starter-log4j2</artifactId>
+				</dependency>
+
+				<dependency>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-core</artifactId>
+					<version>2.7</version>
+				</dependency>
+
+				<dependency>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-slf4j-impl</artifactId>
+					<version>2.7</version>
+				</dependency>
+
+				<dependency>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+					<version>1.7.25</version>
+				</dependency>
+
+				<dependency>
+					<groupId>org.slf4j</groupId>
+					<artifactId>jcl-over-slf4j</artifactId>
+					<version>1.7.25</version>
+				</dependency>
+
+				<dependency>
+					<groupId>org.slf4j</groupId>
+					<artifactId>jul-to-slf4j</artifactId>
+					<version>1.7.25</version>
+				</dependency>
+
+			</dependencies>
+
 			<build>
 				<plugins>
 					<plugin>
@@ -353,6 +392,7 @@
 				</property>
 			</activation>
 			<dependencies>
+
 				<dependency>
 					<groupId>org.springframework.boot</groupId>
 					<artifactId>spring-boot-starter-tomcat</artifactId>
@@ -411,31 +451,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-log4j2</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.12</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-all</artifactId>
-			<version>1.3</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
 			<groupId>net.sourceforge.owlapi</groupId>
 			<artifactId>owlapi-distribution</artifactId>
 			<version>5.0.3</version>
@@ -466,36 +481,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-			<version>2.7</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-slf4j-impl</artifactId>
-			<version>2.7</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>1.7.25</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>jcl-over-slf4j</artifactId>
-			<version>1.7.25</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>jul-to-slf4j</artifactId>
-			<version>1.7.25</version>
-		</dependency>
-
-		<dependency>
 			<groupId>commons-cli</groupId>
 			<artifactId>commons-cli</artifactId>
 			<version>1.3.1</version>
@@ -505,6 +490,26 @@
 			<groupId>org.codehaus.jackson</groupId>
 			<artifactId>jackson-mapper-asl</artifactId>
 			<version>1.9.13</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.12</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-all</artifactId>
+			<version>1.3</version>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>
@@ -527,6 +532,21 @@
 			<version>1.6.4</version>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j-impl</artifactId>
+			<version>2.7</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>2.7</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<pluginRepositories>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,6 @@
 	<properties>
 		<java.version>1.8</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<sprint.boot.version>1.3.2.RELEASE</sprint.boot.version>
 		<mainClass>de.uni_stuttgart.vis.vowl.owl2vowl.ConsoleMain</mainClass>
 		<packaging.type>jar</packaging.type>
 		<authors>Vincent Link, Steffen Lohmann, Eduard Marbach, Vitalis Wiens</authors>
@@ -69,7 +68,7 @@
 				<!-- Import dependency management from Spring Boot -->
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-dependencies</artifactId>
-				<version>1.5.3.RELEASE</version>
+				<version>1.5.6.RELEASE</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -182,20 +181,20 @@
 							</execution>
 						</executions>
 					</plugin>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-gpg-plugin</artifactId>
-						<version>1.6</version>
-						<executions>
-							<execution>
-								<id>sign-artifacts</id>
-								<phase>verify</phase>
-								<goals>
-									<goal>sign</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
+					<!--<plugin>-->
+						<!--<groupId>org.apache.maven.plugins</groupId>-->
+						<!--<artifactId>maven-gpg-plugin</artifactId>-->
+						<!--<version>1.6</version>-->
+						<!--<executions>-->
+							<!--<execution>-->
+								<!--<id>sign-artifacts</id>-->
+								<!--<phase>verify</phase>-->
+								<!--<goals>-->
+									<!--<goal>sign</goal>-->
+								<!--</goals>-->
+							<!--</execution>-->
+						<!--</executions>-->
+					<!--</plugin>-->
 				</plugins>
 			</build>
 		</profile>
@@ -326,7 +325,7 @@
 											</includes>
 										</filter>
 										<filter>
-											<artifact>org.openrdf.sesame:*</artifact>
+											<artifact>org.eclipse.rdf4j:*</artifact>
 											<includes>
 												<include>**</include>
 											</includes>
@@ -420,7 +419,7 @@
 					<plugin>
 						<groupId>org.springframework.boot</groupId>
 						<artifactId>spring-boot-maven-plugin</artifactId>
-						<version>1.3.1.RELEASE</version>
+						<version>1.5.6.RELEASE</version>
 						<executions>
 							<execution>
 								<goals>
@@ -453,7 +452,7 @@
 		<dependency>
 			<groupId>net.sourceforge.owlapi</groupId>
 			<artifactId>owlapi-distribution</artifactId>
-			<version>5.0.3</version>
+			<version>5.1.1</version>
 		</dependency>
 
 		<dependency>
@@ -465,7 +464,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<version>3.5</version>
+			<version>3.6</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/de/uni_stuttgart/vis/vowl/owl2vowl/converter/AbstractConverter.java
+++ b/src/main/java/de/uni_stuttgart/vis/vowl/owl2vowl/converter/AbstractConverter.java
@@ -7,7 +7,12 @@ import de.uni_stuttgart.vis.vowl.owl2vowl.model.entities.AbstractEntity;
 import de.uni_stuttgart.vis.vowl.owl2vowl.model.ontology.OntologyMetric;
 import de.uni_stuttgart.vis.vowl.owl2vowl.parser.owlapi.EntityCreationVisitor;
 import de.uni_stuttgart.vis.vowl.owl2vowl.parser.owlapi.IndividualsVisitor;
-import de.uni_stuttgart.vis.vowl.owl2vowl.parser.vowl.*;
+import de.uni_stuttgart.vis.vowl.owl2vowl.parser.vowl.AnnotationParser;
+import de.uni_stuttgart.vis.vowl.owl2vowl.parser.vowl.BaseIriCollector;
+import de.uni_stuttgart.vis.vowl.owl2vowl.parser.vowl.EquivalentSorter;
+import de.uni_stuttgart.vis.vowl.owl2vowl.parser.vowl.ImportedChecker;
+import de.uni_stuttgart.vis.vowl.owl2vowl.parser.vowl.OntologyInformationParser;
+import de.uni_stuttgart.vis.vowl.owl2vowl.parser.vowl.TypeSetter;
 import de.uni_stuttgart.vis.vowl.owl2vowl.parser.vowl.classes.GenericClassAxiomVisitor;
 import de.uni_stuttgart.vis.vowl.owl2vowl.parser.vowl.classes.HasKeyAxiomParser;
 import de.uni_stuttgart.vis.vowl.owl2vowl.parser.vowl.classes.OwlClassAxiomVisitor;
@@ -15,9 +20,19 @@ import de.uni_stuttgart.vis.vowl.owl2vowl.parser.vowl.property.DataPropertyVisit
 import de.uni_stuttgart.vis.vowl.owl2vowl.parser.vowl.property.DomainRangeFiller;
 import de.uni_stuttgart.vis.vowl.owl2vowl.parser.vowl.property.ObjectPropertyVisitor;
 import de.uni_stuttgart.vis.vowl.owl2vowl.parser.vowl.property.VowlSubclassPropertyGenerator;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.semanticweb.owlapi.model.*;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLClass;
+import org.semanticweb.owlapi.model.OWLClassAxiom;
+import org.semanticweb.owlapi.model.OWLDataProperty;
+import org.semanticweb.owlapi.model.OWLDataPropertyAxiom;
+import org.semanticweb.owlapi.model.OWLObjectProperty;
+import org.semanticweb.owlapi.model.OWLObjectPropertyAxiom;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyCreationException;
+import org.semanticweb.owlapi.model.OWLOntologyManager;
 import org.semanticweb.owlapi.model.parameters.Imports;
 import org.semanticweb.owlapi.search.EntitySearcher;
 import org.semanticweb.owlapi.util.OWLOntologyWalker;
@@ -29,7 +44,9 @@ import java.util.Collection;
  * The sub classes can specify the source of the ontology or to some additional processing if necessary.
  */
 public abstract class AbstractConverter implements Converter {
+
 	private static final Logger logger = LogManager.getLogger(AbstractConverter.class);
+
 	protected final JsonGenerator jsonGenerator = new JsonGenerator();
 	protected String loadedOntologyPath;
 	protected OWLOntologyManager manager;
@@ -50,17 +67,16 @@ public abstract class AbstractConverter implements Converter {
 	protected abstract void loadOntology() throws OWLOntologyCreationException;
 
 	private void preParsing(OWLOntology ontology, VowlData vowlData, OWLOntologyManager manager) {
+
 		OWLOntologyWalker walker = new OWLOntologyWalker(ontology.getImportsClosure());
 		EntityCreationVisitor ecv = new EntityCreationVisitor(vowlData);
-		walker.walkStructure(ecv);
+
 		try {
 			walker.walkStructure(ecv);
-			System.out.println("WalkStructure Success!");
+			logger.info("WalkStructure Success!");
 		} catch (Exception e) {
-			System.out.println("@WORKAROUND WalkSturcture Failed!");
-			System.out.println("Exception: " + e);
-//			System.out.println("Exit without export result, Sorry!");
-//			System.exit(-1);
+			logger.info("@WORKAROUND WalkStructure Failed!");
+			logger.info("Exception: " + e);
 		}
 		new OntologyInformationParser(vowlData, ontology).execute();
 	}
@@ -82,10 +98,10 @@ public abstract class AbstractConverter implements Converter {
 							owlIndividual, owlClass, manager)));
 				}
 				catch (Exception e){
-					System.out.println("@WORKAROUND: Failed to accept some individuals ... SKIPPING THIS"  );
-					System.out.println("Exception: "+e);
-					System.out.println("----------- Continue Process --------");
-					continue;
+					logger.info("@WORKAROUND: Failed to accept some individuals ... SKIPPING THIS"  );
+					logger.info("Exception: "+e);
+					logger.info("----------- Continue Process --------");
+					continue; // FIXME unnecessary continue, can be removed
 				}
 
 			}
@@ -98,10 +114,10 @@ public abstract class AbstractConverter implements Converter {
 				try {
 					owlObjectPropertyAxiom.accept(new ObjectPropertyVisitor(vowlData, owlObjectProperty));
 				} catch (Exception e){
-					System.out.println("          @WORKAROUND: Failed to accept property with HAS_VALUE OR  SubObjectPropertyOf ... SKIPPING THIS"  );
-					System.out.println("          propertyName: "+owlObjectProperty);
-					System.out.println("          propertyAxiom: "+owlObjectPropertyAxiom);
-					continue;
+					logger.info("          @WORKAROUND: Failed to accept property with HAS_VALUE OR  SubObjectPropertyOf ... SKIPPING THIS"  );
+					logger.info("          propertyName: "+owlObjectProperty);
+					logger.info("          propertyAxiom: "+owlObjectPropertyAxiom);
+					continue; // FIXME unnecessary continue, can be removed
 				}
 			}
 		}

--- a/src/main/java/de/uni_stuttgart/vis/vowl/owl2vowl/export/types/JsonGenerator.java
+++ b/src/main/java/de/uni_stuttgart/vis/vowl/owl2vowl/export/types/JsonGenerator.java
@@ -12,6 +12,9 @@ import de.uni_stuttgart.vis.vowl.owl2vowl.model.data.VowlData;
 import de.uni_stuttgart.vis.vowl.owl2vowl.model.ontology.OntologyInformation;
 import de.uni_stuttgart.vis.vowl.owl2vowl.model.ontology.OntologyMetric;
 import de.uni_stuttgart.vis.vowl.owl2vowl.util.ProjectInformations;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.map.SerializationConfig;
 import org.semanticweb.owlapi.model.IRI;
@@ -23,6 +26,9 @@ import java.util.stream.Collectors;
  *
  */
 public class JsonGenerator {
+
+	private static final Logger logger = LogManager.getLogger(JsonGenerator.class);
+
 	private final String VERSION_INFORMATION = "Created with OWL2VOWL (version " + ProjectInformations.getVersion()
 			+ "), http://vowl.visualdataweb.org";
 	private Map<String, Object> root;
@@ -92,16 +98,16 @@ public class JsonGenerator {
 			}
 			catch (Exception e){
 				IRI key =irivEntry.getKey();
-				System.out.println("WARNING! ");
-				System.out.println("*******************************");
-				System.out.println("Failed to Accept!");
-				System.out.println("Entity   "+entity);
-				System.out.println("Key      "+key);
-				System.out.println("Visitor  "+visitor);
-				System.out.println("Reason : "+e);
+				logger.info("WARNING! ");
+				logger.info("*******************************");
+				logger.info("Failed to Accept!");
+				logger.info("Entity   "+entity);
+				logger.info("Key      "+key);
+				logger.info("Visitor  "+visitor);
+				logger.info("Reason : "+e);
 				Class cls = entity.getClass();
-				System.out.println("The type of the object is: " + cls.getName());
-				System.out.println("*** SKIPPING THIS ***");
+				logger.info("The type of the object is: " + cls.getName());
+				logger.info("*** SKIPPING THIS ***");
 				continue;
 			}
 		}

--- a/src/main/java/de/uni_stuttgart/vis/vowl/owl2vowl/parser/vowl/ImportedChecker.java
+++ b/src/main/java/de/uni_stuttgart/vis/vowl/owl2vowl/parser/vowl/ImportedChecker.java
@@ -17,6 +17,9 @@ import java.util.Set;
  *
  */
 public class ImportedChecker implements OWLNamedObjectVisitor {
+
+//	private static final Logger logger = LogManager.getLogger(ImportedChecker.class);
+
 	private final VowlData vowlData;
 	private final OWLOntologyManager manager;
 	private OWLOntology loadedOntology;
@@ -38,10 +41,10 @@ public class ImportedChecker implements OWLNamedObjectVisitor {
 //		});
 
 //		Stream<OWLOntology> imports = manager.imports(loadedOntology);
-//		System.out.println("THE STREAM \n "+imports);
+//		logger.info("THE STREAM \n "+imports);
 //		List<String> strings = imports.map(Object::toString)
 //				.collect(ArrayList::new, ArrayList::add, ArrayList::addAll);
-//		System.out.println("Strings \n "+strings);
+//		logger.info("Strings \n "+strings);
 
 		vowlData.getEntityMap().values().forEach(abstractEntity -> {
 			IRI entityIri = abstractEntity.getIri();

--- a/src/main/java/de/uni_stuttgart/vis/vowl/owl2vowl/parser/vowl/property/DomainRangeFiller.java
+++ b/src/main/java/de/uni_stuttgart/vis/vowl/owl2vowl/parser/vowl/property/DomainRangeFiller.java
@@ -10,6 +10,9 @@ import de.uni_stuttgart.vis.vowl.owl2vowl.model.entities.properties.TypeOfProper
 import de.uni_stuttgart.vis.vowl.owl2vowl.model.entities.properties.VowlDatatypeProperty;
 import de.uni_stuttgart.vis.vowl.owl2vowl.model.entities.properties.VowlObjectProperty;
 import de.uni_stuttgart.vis.vowl.owl2vowl.model.visitor.VowlPropertyVisitor;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.semanticweb.owlapi.model.IRI;
 
 import java.util.Collection;
@@ -20,6 +23,8 @@ import java.util.Set;
  * @author Eduard
  */
 public class DomainRangeFiller implements VowlPropertyVisitor {
+
+	private static final Logger logger = LogManager.getLogger(DomainRangeFiller.class);
 
 	private final VowlData vowlData;
 	private final Collection<? extends AbstractProperty> values;
@@ -43,10 +48,10 @@ public class DomainRangeFiller implements VowlPropertyVisitor {
 			try {
 				element.accept(this);
 			} catch (Exception e){
-				System.out.println("          DomainRange Filler faild to accept element");
-				System.out.println("          Element: "+element);
-				System.out.println("          Reason: "+e);
-				System.out.println("          SKIPPING THIS ELEMENT *****");
+				logger.info("          DomainRange Filler faild to accept element");
+				logger.info("          Element: "+element);
+				logger.info("          Reason: "+e);
+				logger.info("          SKIPPING THIS ELEMENT *****");
 			}
 		});
 	}

--- a/src/main/java/de/uni_stuttgart/vis/vowl/owl2vowl/server/Owl2VowlController.java
+++ b/src/main/java/de/uni_stuttgart/vis/vowl/owl2vowl/server/Owl2VowlController.java
@@ -23,6 +23,8 @@ import java.io.StringWriter;
 @RestController
 public class Owl2VowlController {
 
+	private static final Logger logger = LogManager.getLogger(Owl2VowlController.class);
+
 	private static final Logger conversionLogger = LogManager.getLogger(LoggingConstants.CONVERSION_LOGGER);
 	private static final String СONVERT_MAPPING = "/convert";
 	private static final String READ_JSON = "/read";
@@ -30,21 +32,21 @@ public class Owl2VowlController {
 	@ResponseStatus(value = HttpStatus.BAD_REQUEST, reason = "Parameter not correct")
 	@ExceptionHandler(IllegalArgumentException.class)
 	public void parameterExceptionHandler(Exception e) {
-		System.out.println("--- Parameter exception: " + e.getMessage());
+		logger.info("--- Parameter exception: " + e.getMessage());
 		conversionLogger.error("Problems with parameters: " + e.getMessage());
 	}
 
 	@ResponseStatus(value = HttpStatus.BAD_REQUEST, reason = "Ontology could not be created")
 	@ExceptionHandler(OWLOntologyCreationException.class)
 	public void ontologyCreationExceptionHandler(Exception e) {
-		System.out.println("--- Ontology creation exception: " + e.getMessage());
+		logger.info("--- Ontology creation exception: " + e.getMessage());
 		conversionLogger.error("Problems in ontology creation process: " + e.getMessage());
 	}
 
 	@ResponseStatus(value = HttpStatus.BAD_REQUEST, reason = "Problems while generating uploaded file on server.")
 	@ExceptionHandler(IOException.class)
 	public void fileExceptionHandler(Exception e) {
-		System.out.println("--- IO exception: " + e.getMessage());
+		logger.info("--- IO exception: " + e.getMessage());
 		conversionLogger.error("IO exception while generating file on server: " + e.getMessage());
 	}
 
@@ -118,7 +120,7 @@ public class Owl2VowlController {
 			jsonAsString=IOUtils.toString(inputStreams.get(0));
 		}
 		catch (Exception e){
-			System.out.println("Something went wrong");
+			logger.info("Something went wrong");
 			conversionLogger.error("Something went wrong " + e.getMessage());
 		}
 
@@ -137,7 +139,7 @@ public class Owl2VowlController {
 			}
 		}
 		catch (Exception e){
-			System.out.println("Something went wrong");
+			logger.info("Something went wrong");
 			conversionLogger.error("Something went wrong " + e.getMessage());
 		}
 		return jsonAsString;

--- a/src/main/java/de/uni_stuttgart/vis/vowl/owl2vowl/util/ProjectInformations.java
+++ b/src/main/java/de/uni_stuttgart/vis/vowl/owl2vowl/util/ProjectInformations.java
@@ -13,24 +13,16 @@ public class ProjectInformations {
 	private static String version;
 
 	static {
-		Properties properties = new Properties();
-		InputStream inputStream = ProjectInformations.class.getResourceAsStream(VERSION_PROPERTIES_FILE);
 
-		try {
+		try (InputStream inputStream =
+						 ProjectInformations.class.getResourceAsStream(VERSION_PROPERTIES_FILE)) {
+			Properties properties = new Properties();
 			properties.load(inputStream);
+			version = properties.getProperty("version", "");
 		} catch (IOException e) {
 			System.err.println(VERSION_PROPERTIES_FILE + " not found.");
-		} finally {
-			try {
-				if (inputStream != null) {
-					inputStream.close();
-				}
-			} catch (IOException e) {
-				// Do nothing
-			}
 		}
 
-		version = properties.getProperty("version", "");
 	}
 
 	public static String getVersion() {


### PR DESCRIPTION
In order to integrate OWL2VOWL as a library in other projects, console logging must be replaced by a proper logging framework in order to allow central configuration of logging format and targets (console, files, log servers, etc.)

This merge request:
* moves logging implementations to the `standalone-release` profile in order to avoid binding logging implementation into the "non-standalone" version of the library
* replaces System.out.print by logger.info in all classes except `ConsoleExporter` and `ConsoleMain`
* updates some dependencies
* fixes 2 minor issues
    * improves the readability of `ProjectInformations.java` by using [try-with-resources](https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html)
    * avoids repetition of `walker.walkStructure(ecv)` in `AbstractConverter.java`
    
@steffen-l @seebi 